### PR TITLE
Fix can't disable sourcemap for sass command

### DIFF
--- a/src/leiningen/render.clj
+++ b/src/leiningen/render.clj
@@ -15,7 +15,7 @@
                  (concat ["sassc"] add-opts opts))
 
       :sass (let [opts [ "--update" "--force" "-t" sass-style (str src-path ":" dest-path)]
-                  add-opts (if source-maps ["--sourcemap=auto"] [])]
+                  add-opts (if source-maps ["--sourcemap=auto"] ["--sourcemap=none"])]
                  (concat ["sass"] add-opts opts)))))
 
 (defn render

--- a/src/leiningen/utils.clj
+++ b/src/leiningen/utils.clj
@@ -8,7 +8,8 @@
                                 :style :nested
                                 :command :sassc
                                 :delete-output-dir true
-                                :output-directory "resources/public/css"})
+                                :output-directory "resources/public/css"
+                                :source-maps true})
 
 (defn normalize-options
   [options]


### PR DESCRIPTION
When I'm using `sass` binary (set `:command` to `:sass`), source maps are generated even though I set `:source-maps` to `false`

I found that it looks like sass is generated sourcemap by default since version 3.4
https://github.com/sass/sass/blob/4989ff72ba3fa39071ec937e866e8f38d146ddc5/doc-src/SASS_CHANGELOG.md#smaller-improvements.

So we should explicitly specify `--sourcemap=none` when `:source-maps` config is set to `false`